### PR TITLE
Make PacketEvent's dtor virtual

### DIFF
--- a/src/PacketEvent.h
+++ b/src/PacketEvent.h
@@ -9,6 +9,7 @@ public:
 	bool noResponse = false;
 	// Packet ID needs to be set
 	PacketEventAbstract(uint32_t id);
+	virtual ~PacketEventAbstract() {}
 	//User function to be called when a packet comes in
 	// Buffer contains data from the packet coming in at the start of the function
 	// User data is written into the buffer to send it back 


### PR DESCRIPTION
`PacketEvent` needs to have a virtual destructor so that subclasses' destructors work when calling `delete` on a `PacketEvent*`.